### PR TITLE
Add .podspec file

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "author": "Mike Nedosekin <crespo8800@gmail.com>",
   "license": "MIT",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "homepage": "https://github.com/react-native-community/react-native-masked-view#readme",
   "keywords": [
     "react-native",

--- a/react-native-masked-view.podspec
+++ b/react-native-masked-view.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/react-native-community/react-native-masked-view.git" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
Since react 0.60 is around the corner, we should add podspec file so that automatic linking for iOS works properly