### PR TITLE
Fix pod file (name and git tag)

### DIFF
--- a/RNCMaskedView.podspec
+++ b/RNCMaskedView.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name         = package['name']
+  s.name         = "RNCMaskedView"
   s.version      = package['version']
   s.summary      = package['description']
   s.license      = package['license']
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
   s.platform     = :ios, "9.0"
 
-  s.source       = { :git => "https://github.com/react-native-community/react-native-masked-view.git" }
+  s.source       = { :git => "https://github.com/react-native-community/react-native-masked-view.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'


### PR DESCRIPTION
Run `pod install` after linking (`react-native link @react-native-community/masked-view`) package caused next error:

![pod-install-error](https://user-images.githubusercontent.com/9691761/57293403-52b96880-70cd-11e9-89f9-186c7ac7f760.jpg)