### PR TITLE
remove unused android support library import

### DIFF
--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedViewManager.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedViewManager.java
@@ -1,6 +1,5 @@
 package org.reactnative.maskedview;
 
-import android.support.annotation.Nullable;
 import android.view.View;
 import android.widget.Toast;
 


### PR DESCRIPTION
# Summary

Remove unused Nullable import from Android Support Library, that cause build failures on React Native 0.60+

## Test Plan

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
