### PR TITLE
fix "incorrect peer dependency" warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "react": "^16.0",
-    "react-native": "^0.57"
+    "react-native": ">=0.57"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Currently when installing `@react-native-community/masked-view` with the latest version of RN yarn prints following warning:
> @react-native-community/masked-view@0.1.5" has incorrect peer dependency "react-native@^0.57".

Changing `^` to `>=` in RN version string fixes that issue (the correct version string is also used in `devDependencies`).