### PR TITLE
fix(android): don't crash if maskElement's view is zero sized

### DIFF
--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
@@ -49,6 +49,13 @@ public class RNCMaskedView extends ReactViewGroup {
   public static Bitmap getBitmapFromView(final View view) {
     view.layout(0, 0, view.getMeasuredWidth(), view.getMeasuredHeight());
 
+    // If the maskedElement's underlying View has a zero width or height,
+    // it cannot be rendered into a Bitmap. In this case, we will disable
+    // masking.
+    if (view.getMeasuredWidth() == 0 || view.getMeasuredHeight() == 0) {
+      return null;
+    }
+
     final Bitmap bitmap = Bitmap.createBitmap(view.getMeasuredWidth(),
             view.getMeasuredHeight(), Bitmap.Config.ARGB_8888);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

Fixes a crash in Android if the `maskElement`'s underlying `View` ends up with a zero height or width. I haven't been able to nail down exactly when Android does this, but it was making the entire `MaskedView` view size (0,0) when I re-rendered my very complex page.

This was happening in Android's View layers, not in React, since no amount of setting `minWidth` and `minHeight` in the `maskElement` or in the `MaskedView` itself would prevent the crash.

In any case, I imagine a hard crash of the app isn't the intended behaviour here, so I've suppressed the crash by making the native `RNCMaskedView` not render the bitmap mask if the `View` underlying the `maskElement` ends up with a zero-size.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

Android-only change. Behaviour shouldn't differ in the normal case, change only affects an edge case in Android when the underlying `View` gets a zero size.

### What are the steps to reproduce (after prerequisites)?

Unfortunately I haven't been able to recreate in a minimal project...

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md` (N/A)
- [x] I mentioned this change in `CHANGELOG.md` (??? Where is this?)
- [x] I updated the typed files (TS and Flow) (N/A)
- [x] I added a sample use of the API in the example project (`example/App.js`) (??? Where is this?)
