### PR TITLE
fix(android): Ensure the mask view is not drawn

### DIFF
--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
@@ -42,7 +42,10 @@ public class RNCMaskedView extends ReactViewGroup {
     super.onLayout(changed, l, t, r, b);
 
     if (changed) {
-      this.mBitmapMask = getBitmapFromView(getChildAt(0));
+      View maskView = getChildAt(0);
+      maskView.setAlpha(1);
+      this.mBitmapMask = getBitmapFromView(maskView);
+      maskView.setAlpha(0);
     }
   }
 

--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
@@ -43,9 +43,9 @@ public class RNCMaskedView extends ReactViewGroup {
 
     if (changed) {
       View maskView = getChildAt(0);
-      maskView.setAlpha(1);
+      maskView.setVisibility(View.VISIBLE);
       this.mBitmapMask = getBitmapFromView(maskView);
-      maskView.setAlpha(0);
+      maskView.setVisibility(View.INVISIBLE);
     }
   }
 


### PR DESCRIPTION
# Summary

This allows for masking contents with transparent backgrounds. Previously the mask would be drawn under the content, because it was the child at index 0. This caused it to show through when the content was transparent, which has different behaviour than iOS had.

To do this, we simply set the alpha of the view to 1 before drawing the mask bitmap and than set it to 0 afterwards.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
