### PR TITLE
Redraw mask element on each dispatchDraw

### DIFF
--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
@@ -29,6 +29,9 @@ public class RNCMaskedView extends ReactViewGroup {
   protected void dispatchDraw(Canvas canvas) {
     super.dispatchDraw(canvas);
 
+    // redraw mask element to support animated elements
+    updateBitmapMask();
+
     // draw the mask
     if (mBitmapMask != null) {
       mPaint.setXfermode(mPorterDuffXferMode);
@@ -42,11 +45,19 @@ public class RNCMaskedView extends ReactViewGroup {
     super.onLayout(changed, l, t, r, b);
 
     if (changed) {
-      View maskView = getChildAt(0);
-      maskView.setVisibility(View.VISIBLE);
-      this.mBitmapMask = getBitmapFromView(maskView);
-      maskView.setVisibility(View.INVISIBLE);
+      updateBitmapMask();
     }
+  }
+
+  private void updateBitmapMask() {
+    if (this.mBitmapMask != null) {
+      this.mBitmapMask.recycle();
+    }
+
+    View maskView = getChildAt(0);
+    maskView.setVisibility(View.VISIBLE);
+    this.mBitmapMask = getBitmapFromView(maskView);
+    maskView.setVisibility(View.INVISIBLE);
   }
 
   public static Bitmap getBitmapFromView(final View view) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
I ran into the same issues as some others with an animated `maskElement` on Android, 
https://github.com/react-native-community/react-native-masked-view/issues/22. The bitmap used for masking was drawn on layout, and then cached for future drawing. I changed this to always draw the mask element before applying the mask on the underlying view. 

I am far from an expert on Android development and this might be a bad pattern, but redrawing the bitmap for the mask element on each drawing cycle seems to be performant for me.  
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Use an `Animated.View` as a mask element.

### What are the steps to reproduce (after prerequisites)?
Perform an animation and see that the mask is applied correctly

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
