### PR TITLE
chore: specify files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,14 @@
     "react": "^16.0",
     "react-native": ">=0.57"
   },
+  "files": [
+    "index.js",
+    "android",
+    "ios",
+    "js",
+    "types",
+    "RNCMaskedView.podspec"
+  ],
   "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.6.4",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
When I download `@react-native-community/masked-view`, unnecessary files such as `img` folder and config files are included in the `node_modules`.

By specifying `files` in package.json, it will only download the necessary files to use the masked-view

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
getting only the required files to run masked view on `npm install` and `yarn install`
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
