### PR TITLE
Fix for Android elevation not working inside Masked View child elements 

### DIFF
--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
@@ -19,7 +19,7 @@ public class RNCMaskedView extends ReactViewGroup {
 
   public RNCMaskedView(Context context) {
     super(context);
-    setLayerType(LAYER_TYPE_SOFTWARE, null);
+    setLayerType(LAYER_TYPE_HARDWARE, null);
 
     mPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     mPorterDuffXferMode = new PorterDuffXfermode(PorterDuff.Mode.DST_IN);

--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedViewManager.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedViewManager.java
@@ -1,6 +1,5 @@
 package org.reactnative.maskedview;
 
-import androidx.annotation.NonNull;
 import android.view.View;
 import android.widget.Toast;
 

--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedViewManager.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedViewManager.java
@@ -1,6 +1,6 @@
 package org.reactnative.maskedview;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
 import android.view.View;
 import android.widget.Toast;
 


### PR DESCRIPTION
When Trying to render a ScrollView inside a MaskedView with LinearGradient as a maskElement, on Android all elements with elevation style lose their shadow..

Fixes #15 