### PR TITLE
Add PorterDuff mode prop

### DIFF
--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
@@ -60,6 +60,11 @@ public class RNCMaskedView extends ReactViewGroup {
     maskView.setVisibility(View.INVISIBLE);
   }
 
+  public void setPorterDuffMode(String mode) {
+    PorterDuff.Mode porterDuffMode = PorterDuff.Mode.valueOf(mode);
+    mPorterDuffXferMode = new PorterDuffXfermode(porterDuffMode);
+  }
+
   public static Bitmap getBitmapFromView(final View view) {
     view.layout(0, 0, view.getMeasuredWidth(), view.getMeasuredHeight());
 

--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedViewManager.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedViewManager.java
@@ -27,4 +27,9 @@ public class RNCMaskedViewManager extends ViewGroupManager<RNCMaskedView> {
   protected RNCMaskedView createViewInstance(ThemedReactContext themedReactContext) {
     return new RNCMaskedView(themedReactContext);
   }
+
+  @ReactProp(name = "porterDuffMode")
+  public void setPorterDuffMode(RNCMaskedView view, String mode) {
+    view.setPorterDuffMode(mode);
+  }
 }

--- a/js/MaskedViewTypes.js
+++ b/js/MaskedViewTypes.js
@@ -10,4 +10,23 @@ export type MaskedViewProps = typeof ViewPropTypes &
      * mask for the child element.
      */
     maskElement: Element<any>,
+    porterDuffMode?:
+      | 'ADD'
+      | 'CLEAR'
+      | 'DARKEN'
+      | 'DST'
+      | 'DST_ATOP'
+      | 'DST_IN'
+      | 'DST_OUT'
+      | 'DST_OVER'
+      | 'LIGHTEN'
+      | 'MULTIPLY'
+      | 'OVERLAY'
+      | 'SCREEN'
+      | 'SRC'
+      | 'SRC_ATOP'
+      | 'SRC_IN'
+      | 'SRC_OUT'
+      | 'SRC_OVER'
+      | 'XOR',
   |}>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,25 @@ import * as ReactNative from 'react-native';
 
 interface MaskedViewProps extends ReactNative.ViewProps {
   maskElement: React.ReactElement;
+  porterDuffMode?:
+    | 'ADD'
+    | 'CLEAR'
+    | 'DARKEN'
+    | 'DST'
+    | 'DST_ATOP'
+    | 'DST_IN'
+    | 'DST_OUT'
+    | 'DST_OVER'
+    | 'LIGHTEN'
+    | 'MULTIPLY'
+    | 'OVERLAY'
+    | 'SCREEN'
+    | 'SRC'
+    | 'SRC_ATOP'
+    | 'SRC_IN'
+    | 'SRC_OUT'
+    | 'SRC_OVER'
+    | 'XOR';
 }
 /**
  * @see https://github.com/react-native-community/react-native-masked-view


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
This should fix #51 and #78.
As masking an image with an alpha mask image didn't work on Android, I added a prop to the MaskedView to set the PorterDuff mode on Android. With `SRC_OUT` I could successfully mask an image with another image.
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Insert an image into the `maskElement` prop and inside `MaskView` insert an alpha mask image.
### What are the steps to reproduce (after prerequisites)?
The alpha mask image should be correctly applied to the image.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌ (already works on iOS)     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
