### PR TITLE
fix(android): invalidate mask bitmap for descendant updates

### DIFF
--- a/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
+++ b/android/src/main/java/org/reactnative/maskedview/RNCMaskedView.java
@@ -7,6 +7,7 @@ import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.view.View;
+import android.view.ViewParent;
 
 import com.facebook.react.views.view.ReactViewGroup;
 
@@ -52,10 +53,11 @@ public class RNCMaskedView extends ReactViewGroup {
 
     if (!mBitmapMaskInvalidated) {
       View maskView = getChildAt(0);
-      if (maskView != null) {
-        if (maskView.equals(child)) {
-          mBitmapMaskInvalidated = true;
-        }
+      // OEM-specific invalidation propagation may report either the direct mask child
+      // or a deeper descendant here, so invalidate the cached bitmap for the whole
+      // mask subtree rather than only for the direct child.
+      if (maskView != null && isDescendantOfMaskView(maskView, child)) {
+        mBitmapMaskInvalidated = true;
       }
     }
 
@@ -108,5 +110,17 @@ public class RNCMaskedView extends ReactViewGroup {
 
   public void setRenderingMode(String renderingMode) {
     mRenderingMode = renderingMode.equals("software") ? View.LAYER_TYPE_SOFTWARE : View.LAYER_TYPE_HARDWARE;
+  }
+
+  private boolean isDescendantOfMaskView(View maskView, View child) {
+    View current = child;
+    while (current != null) {
+      if (current == maskView) {
+        return true;
+      }
+      ViewParent parent = current.getParent();
+      current = parent instanceof View ? (View) parent : null;
+    }
+    return false;
   }
 }


### PR DESCRIPTION
## Summary

On some Android OEM builds, `onDescendantInvalidated(child, target)` may report a deeper descendant from the mask subtree instead of the direct mask child.


This works when the callback reports the direct child, but misses updates when the callback reports a nested descendant such as a TextView. In that case, dynamic text updates inside the mask can fail to refresh the cached bitmap on some devices.

## Changes
invalidate the cached mask bitmap when the invalidated child belongs to the mask subtree
add a short comment documenting the OEM-specific propagation difference
## Why
This keeps the existing behavior for direct child invalidation while fixing Android devices that propagate descendant invalidation differently.

## Notes
I observed this with a hierarchy like:
```java
RNCMaskedView
└── mask ViewGroup
    └── TextView
```
On some devices the callback reports child = mask ViewGroup, while on others it reports child = TextView.